### PR TITLE
Fix Alpine 3.13 not working on raspberry pi

### DIFF
--- a/src/dothdns/container_configs/doh-docker/Dockerfile
+++ b/src/dothdns/container_configs/doh-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.12
 
 ARG BUILD_DATE
 ARG VERSION


### PR DESCRIPTION
Set doh-docker Dockerfile to use alpine:3.12 rather than latest to fix incompatibility with raspberry pi.